### PR TITLE
Fix fetchmanager bug from empty body response

### DIFF
--- a/src/main/java/com/wannaone/woowanote/web/ApiUserController.java
+++ b/src/main/java/com/wannaone/woowanote/web/ApiUserController.java
@@ -31,7 +31,7 @@ public class ApiUserController {
     @PostMapping("/login")
     public ResponseEntity login(@RequestBody @Valid LoginDto loginDto, HttpSession session) {
         SessionUtil.setMember(session, userService.login(loginDto));
-        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON_UTF8).body(new LoginDto());
+        return new ResponseEntity(HttpStatus.OK);
     }
 
 

--- a/src/main/resources/static/js/signup.js
+++ b/src/main/resources/static/js/signup.js
@@ -48,7 +48,7 @@ class SignUp {
     }
 
     signUpSuccessCallback() {
-        document.location.href = '/main.html';
+        document.location.href = '/signup.html';
     }
 
     signUpFailureCallback() {

--- a/src/main/resources/static/js/util.js
+++ b/src/main/resources/static/js/util.js
@@ -14,7 +14,7 @@ function fetchManager({ url, method, body, headers, onSuccess, onFailure}) {
         credentials: "same-origin"
     }).then((response) => {
         if(response.ok) {
-            response.json().then((result) => onSuccess(result))
+            response.json().then((result) => onSuccess(result)).catch(() => onSuccess());
         } else {
             onFailure(response);
         }


### PR DESCRIPTION
- resolve #11 and #49 issue
- catch exception when body is empty in fetchmanager
- remove redundant body when user login
- change redirection url from main to login page when signing up